### PR TITLE
packages: Rewrite search to use xq-api

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,8 @@
 		<link href='/assets/css/font-ubuntu.css' rel='stylesheet' type='text/css'>
 		{% if site.snow == 1 %}<link rel="stylesheet" type="text/css" href="/assets/css/snow.css" />{% endif %}
 		<link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml" />
+		<script src="/assets/js/jquery.min.js"></script>
+		<script src="/assets/js/bootstrap.min.js"></script>
 	</head>
 	<body role="document">
 		<nav class="navbar navbar-default navbar-inverse navbar-fixed-top" role="navigation">
@@ -49,8 +51,6 @@
 					<p class="text-center">Linux&#174; is a registered trademark of Linus Torvalds (<a href="http://www.linuxfoundation.org/programs/legal/trademark/attribution">info</a>)</p>
 				</footer>
 			</div>
-			<script src="/assets/js/jquery.min.js"></script>
-			<script src="/assets/js/bootstrap.min.js"></script>
 		</div>
 	</body>
 </html>

--- a/assets/css/misc.css
+++ b/assets/css/misc.css
@@ -105,12 +105,12 @@ img, .video {
 	display: inline;
 
 }
-#voidSearch_box {
+#voidSearch_query {
 	border:1px inset;
 	background:white;
 	padding:5pt;
 }
-#voidSearch_box.loading {
+#voidSearch_query.loading {
 	background-image:url(../img/loading.gif);
 	background-repeat:no-repeat;
 	background-position:center right;
@@ -121,8 +121,9 @@ img, .video {
 	margin:left;
 }
 
-#voidSearch_result td {
-	padding:10px;
+#voidSearch_result td,
+#voidSearch_result th {
+	padding:5pt;
 }
 #voidSearch_result td.version,
 #voidSearch_result td.revision,

--- a/packages/index.markdown
+++ b/packages/index.markdown
@@ -5,15 +5,18 @@ title: Enter the void - Packages
 
 <div>
 <h2>Find binary packages</h2>
- <p>Search for available binary packages in the official repository index matching simple keywords.</p>
- <form method="GET" action="https://github.com/void-linux/void-packages/search" onkeypress="return event.keyCode != 13;">
- <input type="hidden" name="q[]" value="filename:template path:/srcpkgs" />
- <input type="text" name="q[]" placeholder="Package name" id="voidSearch_box" onkeyup="if(window.voidSearch)window.voidSearch()" />
- <input type="hidden" name="s" value="indexed" />
- <table id="voidSearch_result"></table>
- <button type="submit">Search on Github</button>
+ <p>Search for available binary packages in the official repodata index matching simple keywords.</p>
+ <form id="voidSearch">
+ <select name="arch" id="voidSearch_archs">
+ <option value="x86_64">x86_64</option>
+ </select>
+ <input type="text" name="q" placeholder="Package or description" id="voidSearch_query"/>
+ <button type="submit" id="voidSearch_submit">Search</button>
  </form>
- <script src="/assets/js/voidsearch.js" async></script>
+ <table id="voidSearch_result">
+ </table>
+
+<script src="/assets/js/voidsearch.js" async></script>
 
 <h2>Latest package commits <span class="rssdev"><a href="https://github.com/void-linux/void-packages/commits/master.atom" title="Subscribe to void-packages"><i class="fa fa-rss fa-lg"></i></a></span></h2>
  <ul>


### PR DESCRIPTION
This replaces the package search with a primitive one through xq-api.
Due to a limitation of the API, the architecture list is a drop-down
instead of being presented in the table -- so, users have to
unfortunately know which architecture they want to search.

The architectures list is populated by the API, so if a new one is
added (e.g., PowerPC), then it should be picked up automatically with
an xq-api reload.

This also moves the jquery and bootstrap scripts into the page head.
There's a chance this could slow down page rendering a bit, but without
the ability to add scripts to the end of the body after jquery, the
voidsearch.js and others can't make use of jquery reliably. So, a small
hit that shouldn't be noticable after caching seems better than writing
a bunch of code to work around browser load order.

This cannot be merged until void-linux/void-infrastructure#20 is good to
go and an xq-api server is available.