### PR TITLE
atom.xml: escape title

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -17,7 +17,7 @@ layout: nil
 
 {% for post in site.posts limit:20 %}
 	<entry>
-		<title>{{ post.title }}</title>
+		<title>{{ post.title | xml_escape }}</title>
 		<link href="http://voidlinux.org{{ post.url }}"/>
 		<id>http://voidlinux.org{{ post.id }}</id>
 		<published>{{ post.date | date_to_xmlschema }}</published>


### PR DESCRIPTION
`/atom.xml` is currently broken because of lack of escaping:
```
XML Parsing Error: not well-formed
Location: https://voidlinux.org/atom.xml
Line Number 24, Column 38:		<title>The Life of a Pull Request & Where Commit Bits Come From</title>
---------------------------------------------------^
```