### PR TITLE
site: docs instead of wiki in navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,7 +33,7 @@
 						<li><a href="/news/">News</a></li>
 						<li><a href="/download/">Download</a></li>
 						<li><a href="/packages/">Packages</a></li>
-						<li><a href="https://wiki.voidlinux.org">Wiki</a></li>
+						<li><a href="https://docs.voidlinux.org">Documentation</a></li>
 						<li><a href="https://reddit.com/r/voidlinux">Forum</a></li>
 						<li><a href="https://github.com/void-linux">GitHub</a></li>
 					</ul>


### PR DESCRIPTION
Removes the Wiki from the Navigation, adds Documentation instead (to docs.voidlinux.org)

The wiki isn't maintained anymore and has plain wrong information in it, the "Post Installation" site especially is nothing I'd want a new user to consume.

Even with information missing from docs, I think too sparse documentation is better than wrong.

Another point is that new registrations for the wiki aren't possible anymore.