### PR TITLE
Add 'Contribute' page.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,6 +35,7 @@
 						<li><a href="/packages/">Packages</a></li>
 						<li><a href="https://docs.voidlinux.org">Documentation</a></li>
 						<li><a href="https://reddit.com/r/voidlinux">Forum</a></li>
+						<li><a href="/contribute/">Join Us</a></li>
 						<li><a href="https://github.com/void-linux">GitHub</a></li>
 					</ul>
 				</div>

--- a/contribute/index.markdown
+++ b/contribute/index.markdown
@@ -1,0 +1,12 @@
+---
+layout: std
+title: Enter the Void - Join Us
+---
+
+# Join Us
+
+To help with adding or updating Void packages, start by visiting [CONTRIBUTING](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md).
+
+To help with adding or updating [the documentation](https://docs.voidlinux.org/), start by visiting [this section of the Void Handbook](https://docs.voidlinux.org/contributing/void-docs/index.html).
+
+If you have any questions, ask them via IRC in #voidlinux on irc.freenode.net, or in [the forum](https://www.reddit.com/r/voidlinux).


### PR DESCRIPTION
The PR seeks to make it easier for people to find CONTRIBUTING and the "Contributing > Void Docs" section of the Handbook, with the intent of (hopefully) reducing the number of PRs which don't follow project guidelines.