### PR TITLE
Add manual pages to the menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,6 +34,7 @@
 						<li><a href="/download/">Download</a></li>
 						<li><a href="/packages/">Packages</a></li>
 						<li><a href="https://docs.voidlinux.org">Documentation</a></li>
+                        <li><a href="https://man.voidlinux.org/">Manual Pages</a></li>
 						<li><a href="https://reddit.com/r/voidlinux">Forum</a></li>
 						<li><a href="https://github.com/void-linux">GitHub</a></li>
 					</ul>


### PR DESCRIPTION
This is not strictly necessary, but I still think it is very convenient since the manual pages are online. I wasn't on Void and needed to look something specific up, that's how I discovered the manual pages for Void online searching on Duckduckgo. Also both FreeBSD and OpenBSD has their manual pages online in a similar manner.