### PR TITLE
Fix deprecation warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,5 +9,5 @@ permalink:   /news/:year/:month/:title.html
 
 snow:        0
 
-gems:
+plugins:
   - jekyll-redirect-from


### PR DESCRIPTION
> Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.