### PR TITLE
_layouts/default: add Manual Pages link.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,6 +34,7 @@
 						<li><a href="/download/">Download</a></li>
 						<li><a href="/packages/">Packages</a></li>
 						<li><a href="https://docs.voidlinux.org">Documentation</a></li>
+						<li><a href="https://man.voidlinux.org/">Manual Pages</a></li>
 						<li><a href="https://www.reddit.com/r/voidlinux">Forum</a></li>
 						<li><a href="/contribute/">Join Us</a></li>
 						<li><a href="https://github.com/void-linux">GitHub</a></li>


### PR DESCRIPTION
Closes #86 

I'm not in love with this change, because it requires, at a minimum, changing the header in void-docs and in the man.voidlinux.org (ironically enough), if we want to keep everything consistent.