### PR TITLE
Packages search - tweak form style

### DIFF
--- a/assets/css/misc.css
+++ b/assets/css/misc.css
@@ -105,11 +105,6 @@ img, .video {
 	display: inline;
 
 }
-#voidSearch_query {
-	border:1px inset;
-	background:white;
-	padding:5pt;
-}
 #voidSearch_query.loading {
 	background-image:url(../img/loading.gif);
 	background-repeat:no-repeat;
@@ -167,4 +162,14 @@ img, .video {
 h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
 	padding-top:50px;
 	margin-top:-40px;
+}
+.btn-green {
+	color: #fff;
+	background-color: #478061;
+	border-color: #478061;
+}
+.btn-green:hover {
+	color: #fff;
+	background-color: black;
+	border-color: black;
 }

--- a/packages/index.markdown
+++ b/packages/index.markdown
@@ -5,16 +5,19 @@ title: Enter the void - Packages
 
 <div>
 <h2>Find binary packages</h2>
- <p>Search for available binary packages in the official repodata index matching simple keywords.</p>
- <form id="voidSearch">
- <select name="arch" id="voidSearch_archs">
- <option value="x86_64">x86_64</option>
- </select>
- <input type="text" name="q" placeholder="Package or description" id="voidSearch_query"/>
- <button type="submit" id="voidSearch_submit">Search</button>
- </form>
- <table id="voidSearch_result">
- </table>
+<p>Search for available binary packages in the official repodata index matching simple keywords.</p>
+<form class="form-inline" id="voidSearch">
+ <div class="form-group">
+  <select name="arch" class="form-control" id="voidSearch_archs">
+   <option value="x86_64">x86_64</option>
+  </select>
+ </div>
+ <div class="form-group">
+  <input type="text" name="q" placeholder="Package or description" class="form-control" id="voidSearch_query"/>
+ </div>
+ <button type="submit" class="btn btn-green" id="voidSearch_submit">Search</button>
+</form>
+<table id="voidSearch_result"></table>
 
 <script src="/assets/js/voidsearch.js" async></script>
 


### PR DESCRIPTION
I added some Bootstrap classes to package search form to make it look more consistent.

![void_package_search](https://user-images.githubusercontent.com/14090004/91448945-d24ae800-e87a-11ea-8361-24dad4c6aa80.png)