### PR TITLE
Add acknowledgments page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,4 +245,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,6 +33,7 @@
 						<li><a href="/news/">News</a></li>
 						<li><a href="/download/">Download</a></li>
 						<li><a href="/packages/">Packages</a></li>
+						<li><a href="/acknowledgments/">Acknowledgments</a></li>
 						<li><a href="https://docs.voidlinux.org">Documentation</a></li>
 						<li><a href="https://man.voidlinux.org/">Manual Pages</a></li>
 						<li><a href="https://github.com/void-linux">GitHub</a></li>

--- a/acknowledgments/index.md
+++ b/acknowledgments/index.md
@@ -1,0 +1,35 @@
+---
+layout: std
+title: Acknowledgments
+---
+
+# Acknowledging our Sponsors
+
+Void is a project that stands upon the work of over 700 individual
+contributors.  All of this work, however, needs to be transformed by
+compilation into usable packages and system images for end users to
+download and enjoy.  The build artifacts must then be mirrored and
+served, and all of this infrastructure must be monitored and
+maintained.  On this page we'd like to thank the organizations and
+individuals that supply hardware for Void's use.
+
+## [DigitalOcean](https://www.digitalocean.com/)
+
+DigitalOcean sponsors a number of virtual machines which run various
+infrastructure needs that support the rest of the fleet.  Their
+support has enabled us to move non-build tasks off of build machines,
+improving the reliability of these services and the resources
+available for builds.
+
+## [Enno Boland IT](https://ebo.land)
+
+Enno Boland IT sponsors the glibc build machine, mail servers, and
+root mirror.
+
+## [Leah Neukirchen](http://leahneukirchen.org/)
+
+Leah Neukirchen sponsors the aarch64 build machine.
+
+## [Tj Vanderpoel](#)
+
+Tj Vanderpoel sponsors the musl build machine.


### PR DESCRIPTION
This PR adds an acknowledgements page that thanks those who sponsor the hardware that comprises the Void fleet.

@leahneukirchen, @bougyman, @Gottox please verify that you appear in this file as you wish to be represented.

@void-linux/webmasters for patch review and approval.