### PR TITLE
Add download links to the download page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,10 @@ snow:        0
 
 plugins:
   - jekyll-redirect-from
+
+collections:
+  platforms:
+    output: true
+
+download_mirror: https://alpha.de.repo.voidlinux.org/live/current
+download_build_date: 2019-11-09

--- a/_includes/download_arm.html
+++ b/_includes/download_arm.html
@@ -1,0 +1,30 @@
+<div class="split-section">
+  <div>
+    <h3 id="{{ page.name }}">{{ page.name }}</h3>
+    {{ include.content | markdownify }}
+  </div>
+  <div>
+    {% for device in page.devices %}
+    <div class="download-device-title">
+      <h4>{{ device }}</h4>
+      <small>{{ site.download_build_date }}</small>
+    </div>
+    <ul class="inline-download-links">
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ device }}-ROOTFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
+          >rootfs tarball</a
+        >
+        <span class="label label-default">glibc</span>
+      </li>
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ device }}-musl-ROOTFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
+          >rootfs tarball</a
+        >
+        <span class="label label-warning">musl</span>
+      </li>
+    </ul>
+    {% endfor %}
+  </div>
+</div>

--- a/_includes/download_details_pc.md
+++ b/_includes/download_details_pc.md
@@ -1,0 +1,5 @@
+Installable live images support a local installation (with the included packages) or a network installation (packages are downloaded from official repository).
+
+You can log into these images as `anon` or `root`, and the password is `voidlinux`.
+
+To start the installer, execute the `void-installer` utility with appropriate permissions (i.e., `sudo void-installer`).

--- a/_includes/download_pc.html
+++ b/_includes/download_pc.html
@@ -1,0 +1,75 @@
+<div class="split-section">
+  <div>
+    <h3 id="{{ page.name }}">{{ page.name }}</h3>
+    {{ include.content | markdownify }}
+    <div class="alert alert-warning" role="alert">
+      To install the packages for the desktop environment, DON'T choose "install
+      from network" choose the "local install" option.
+    </div>
+  </div>
+  <div>
+    <div class="download-device-title">
+      <h4>base</h4>
+      <small>{{ site.download_build_date }}</small>
+    </div>
+    <ul class="inline-download-links">
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-live-{{ page.name }}-{{ site.download_build_date | date: '%Y%m%d' }}.iso"
+          >Live image</a
+        >
+        <span class="label label-default">glibc</span>
+      </li>
+      {% if page.supports_musl %}
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-live-{{ page.name }}-musl-{{ site.download_build_date | date: '%Y%m%d' }}.iso"
+          >Live image</a
+        >
+        <span class="label label-warning">musl</span>
+      </li>
+      {% endif %}
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ page.name }}-ROOTFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
+          >rootfs tarball</a
+        >
+        <span class="label label-default">glibc</span>
+      </li>
+      {% if page.supports_musl %}
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ page.name }}-musl-ROOTFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
+          >rootfs tarball</a
+        >
+        <span class="label label-warning">musl</span>
+      </li>
+      {% endif %}
+    </ul>
+
+    {% for flavor in page.flavors %}
+    <div class="download-device-title">
+      <h4>{{ flavor | downcase }}</h4>
+      <small>{{ site.download_build_date }}</small>
+    </div>
+    <ul class="inline-download-links">
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-live-{{ page.name }}-{{ site.download_build_date | date: '%Y%m%d' }}-{{ flavor | downcase }}.iso"
+          >Live image</a
+        >
+        <span class="label label-default">glibc</span>
+      </li>
+      {% if page.supports_musl %}
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-live-{{ page.name }}-musl-{{ site.download_build_date | date: '%Y%m%d' }}-{{ flavor | downcase }}.iso"
+          >Live image</a
+        >
+        <span class="label label-warning">musl</span>
+      </li>
+      {% endif %}
+    </ul>
+    {% endfor %}
+  </div>
+</div>

--- a/_includes/download_sbc.html
+++ b/_includes/download_sbc.html
@@ -1,0 +1,49 @@
+<div class="split-section">
+  <div>
+    <h3 id="{{ page.name }}">{{ page.name }}</h3>
+    {{ include.content | markdownify }}
+  </div>
+  <div>
+    {% for device in page.devices %}
+    <div class="download-device-title">
+      <h4>
+        {{ device.name }}
+        {% if device.arch %}
+        ({{ device.arch }})
+        {% endif %}
+      </h4>
+      <small>{{ site.download_build_date }}</small>
+    </div>
+    <ul class="inline-download-links">
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ device.name }}-{{ site.download_build_date | date: '%Y%m%d' }}.img.xz"
+          >Live image</a
+        >
+        <span class="label label-default">glibc</span>
+      </li>
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ device.name }}-musl-{{ site.download_build_date | date: '%Y%m%d' }}.img.xz"
+          >Live image</a
+        >
+        <span class="label label-warning">musl</span>
+      </li>
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ device.name }}-PLATFORMFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
+          >rootfs tarball</a
+        >
+        <span class="label label-default">glibc</span>
+      </li>
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ device.name }}-musl-PLATFORMFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
+          >rootfs tarball</a
+        >
+        <span class="label label-warning">musl</span>
+      </li>
+    </ul>
+    {% endfor %}
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
 		<link rel="alternate" type="application/atom+xml" title="Atom feed" href="/atom.xml" />
 		<script src="/assets/js/jquery.min.js"></script>
 		<script src="/assets/js/bootstrap.min.js"></script>
+		<script src="/assets/js/tabbar.js"></script>
 	</head>
 	<body role="document">
 		<nav class="navbar navbar-default navbar-inverse navbar-fixed-top" role="navigation">

--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+<div class="container">
+  {{ content }}
+
+  <ul class="tab-bar" id="tab-bar">
+    {% for platform in site.platforms %}
+    <li>
+      <a href="#{{  platform.name }}">{{ platform.name }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+
+  <div id="tab-content">
+    {% for platform in site.platforms %}
+    <div>
+      {{ platform.content }}
+      <noscript>
+        <hr />
+      </noscript>
+    </div>
+    {% endfor %}
+  </div>
+  <section id="tab-content"></section>
+</div>

--- a/_platforms/arm.md
+++ b/_platforms/arm.md
@@ -1,0 +1,15 @@
+---
+name: arm
+date: 1970-01-01 04:00:00
+devices: [armv6l, armv7l, aarch64]
+---
+
+{% capture download_details %} 
+ROOTFS tarballs can be extracted to a previously prepared partition scheme or
+used for chroot installation.
+
+General and platform specific instructions are available [in the
+documentation](https://docs.voidlinux.org/installation/guides/arm-devices/index.html).
+{% endcapture %}
+
+{% include download_arm.html content=download_details %}

--- a/_platforms/i686.md
+++ b/_platforms/i686.md
@@ -1,0 +1,12 @@
+---
+name: i686
+date: 1970-01-01 03:00:00
+flavors: [enlightenment, cinnamon, lxde, lxqt, mate, xfce]
+supports_musl: false
+---
+
+{% capture download_details %}
+{% include download_details_pc.md %}
+{% endcapture %}
+
+{% include download_pc.html content=download_details %}

--- a/_platforms/sbc.md
+++ b/_platforms/sbc.md
@@ -1,0 +1,36 @@
+---
+name: arm platforms
+date: 1970-01-01 05:00:00
+devices:
+- name: beaglebone
+  arch: armv7
+- name: cubieboard2
+  arch: armv7
+- name: odroid-c2
+  arch: armv7
+- name: rpi
+  arch: armv6
+- name: rpi2
+  arch: armv7
+- name: rpi3
+  arch: aarch64
+- name: usbarmory
+  arch: armv7
+---
+
+{% capture download_details %}
+Live images can be written onto an SD card (i.e. using `dd`) and they provide you with a ready to boot system. These images are prepared for 2GB SD cards. Alternatively, use the ROOTFS tarballs if you want to customize the partitions and filesystems.
+
+Connect to the system using a virtual terminal or SSH and log in as `root` with password `voidlinux`.
+
+Platform specific instructions for these images are available [in the documentation](https://docs.voidlinux.org/installation/guides/arm-devices/platforms.html).
+
+Deprecated instructions for the following platforms can be found in these wiki pages (you can help by porting them over to the [Void Handbook](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md)):
+
+- [BeagleBone/BeagleBone Black](https://wiki.voidlinux.org/Beaglebone)
+- [Cubieboard2](https://wiki.voidlinux.org/Cubieboard2_SD-Card)
+- [Odroid U2/U3](https://wiki.voidlinux.org/Odroid_U2)
+- [USB Armory](https://wiki.voidlinux.org/USB_Armory)
+{% endcapture %}
+
+{% include download_sbc.html content=download_details %}

--- a/_platforms/x86_64.md
+++ b/_platforms/x86_64.md
@@ -1,0 +1,12 @@
+---
+name: x86_64
+date: 1970-01-01 01:00:00
+flavors: [enlightenment, cinnamon, lxde, lxqt, mate, xfce]
+supports_musl: true
+---
+
+{% capture download_details %}
+{% include download_details_pc.md %}
+{% endcapture %}
+
+{% include download_pc.html content=download_details %}

--- a/assets/css/misc.css
+++ b/assets/css/misc.css
@@ -173,3 +173,91 @@ h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
 	background-color: black;
 	border-color: black;
 }
+
+.tab-bar {
+  list-style: none;
+  display: flex;
+  padding: 0;
+  margin: 0;
+  border-bottom: 1px solid #ddd;
+}
+.tab-bar li {
+  padding: 1em 2em;
+  cursor: pointer;
+  border-bottom: 2px solid white;
+  transition: border-color 0.4s;
+}
+.tab-bar li:hover {
+  border-bottom: 2px solid #ddd;
+}
+.tab-bar li.active {
+  font-weight: bold;
+  border-bottom: 2px solid #478061;
+}
+@media (max-width: 500px) {
+  .tab-bar li {
+    padding: 1em;
+  }
+}
+.tab-bar li a {
+  color: inherit;
+}
+.tab-bar li a:focus {
+  text-decoration: none;
+}
+
+.split-section {
+  display: flex;
+  flex-wrap: wrap;
+}
+.split-section h3 {
+  margin-top: 20px;
+  padding-top: 0;
+}
+.split-section > div {
+  flex: 1;
+}
+.split-section > div:first-of-type {
+  padding-right: 4rem;
+}
+@media (max-width: 600px) {
+  .split-section {
+    flex-direction: column;
+  }
+  .split-section > div:first-of-type {
+    padding-right: 0;
+  }
+}
+
+.download-device-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.download-device-title h4 {
+  margin-top: 2rem;
+}
+
+.inline-download-links {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  border-bottom: 1px solid #ddd;
+}
+.inline-download-links:last-of-type {
+  border-bottom: none;
+}
+.inline-download-links li {
+  margin-right: 1.5em;
+  margin-bottom: 2rem;
+}
+.inline-download-links .label-warning {
+  background-color: #fdf6e3;
+  color: #535353;
+}
+.inline-download-links .label-default {
+  background-color: #ddd;
+  color: #535353;
+}

--- a/assets/js/tabbar.js
+++ b/assets/js/tabbar.js
@@ -1,0 +1,24 @@
+window.addEventListener("DOMContentLoaded", () => {
+  const tabBar = document.getElementById("tab-bar");
+  if (tabBar) setupTabBar(tabBar, document.getElementById("tab-content"));
+});
+
+function setupTabBar(el, contentEl) {
+  let selectedIdx = 0;
+  selectTabItem(el, contentEl, selectedIdx);
+  for (let idx = 0; idx < el.children.length; idx++) {
+    el.children[idx].addEventListener("click", (e) => {
+      e.preventDefault();
+      selectTabItem(el, contentEl, idx);
+    });
+  }
+}
+
+function selectTabItem(tabBar, content, selectedIdx) {
+  for (let idx = 0; idx < tabBar.children.length; idx++) {
+    tabBar.children[idx].classList.remove("active");
+    content.children[idx].classList.add("hidden");
+  }
+  tabBar.children[selectedIdx].classList.add("active");
+  content.children[selectedIdx].classList.remove("hidden");
+}

--- a/download/index.markdown
+++ b/download/index.markdown
@@ -1,15 +1,12 @@
 ---
-layout: std
+layout: download
 title: Enter the void - Downloads
 ---
-* TOC
-{:toc}
-
 ## Download installable base live images and rootfs tarballs
 
 All **live images** and **rootfs tarballs** are available at:
 
-- [https://alpha.de.repo.voidlinux.org/live/current](https://alpha.de.repo.voidlinux.org/live/current)
+- [{{ site.download_mirror }}]({{ site.download_mirror }})
 
 These files can also be downloaded from other mirrors, which are listed [in the documentation](https://docs.voidlinux.org/xbps/repositories/mirrors/index.html).
 Simply navigate to `live -> current` to find them.
@@ -23,96 +20,3 @@ Prior to using any image you're strongly encouraged to validate the
 signatures on the image to ensure they haven't been tampered with.
 The process for validating these keys can be found [in the
 documentation](https://docs.voidlinux.org/installation/index.html#downloading-installation-media).
-
-## Download installable base live images for x86
-
-***PLEASE NOTE: To install the desktop environment, DON'T choose "install from network" choose the local install. VERY IMPORTANT!***
-
-Currently there are installable live images for the **i686** and **x86\_64** architectures
-and there is support to make a local installation (with the included packages) or a network
-installation (packages are downloaded from official repository).
-
-Log in as `anon`/`root`, password `voidlinux`.
-
-To start the installer just execute the `void-installer` utility with enough permissions (i.e., `sudo`).
-
-Additional live images with *flavors* (an additional Desktop Environment with autologin) are also
-available:
-
-- Enlightenment
-- Cinnamon
-- LXDE
-- LXQT
-- MATE
-- XFCE
-
-These images are named `void-live-ARCH-BUILD_DATE[-FLAVOR].iso`, where
-
-- `ARCH` is the architecture of the image, which can be:
-   - `x86_64`
-   - `x86_64-musl`
-   - `i686`
-- `BUILD_DATE` is the date the image was built
-- `FLAVOR` is optional, and specifies which flavor the image contains
-
-These images need at least 256 or 512 MB of RAM in order to work correctly.
-
-## Download ready to boot images for ARM
-
-There are ready to boot images for several **ARM** devices. These images can be written onto an SD card (i.e. using `dd`)
-and they allow you to have a ready to boot system. These images are prepared for 2GB SD cards. Alternatively, use the
-rootfs tarballs if you want to customize the partitions and filesystems.
-
-These images are named `void-DEVICE[-musl]-BUILD_DATE.img.xz`, where
-
-- `DEVICE` is the device for which the image was built, which can be:
-   - `beaglebone`: BeagleBone/BeagleBone Black (ARMv7, hard float)
-   - `cubieboard2`: Cubieboard2 (ARMv7, hard float)
-   - `odroid-c2`: Odroid U2/U3 (ARMv7, hard float)
-   - `rpi`: Raspberry Pi and Raspberry Pi Zero (ARMv6, hard float)
-   - `rpi2`: Raspberry Pi 2 (ARMv7, hard float)
-   - `rpi3`: Raspberry Pi 3 (AARCH64, hard float)
-   - `usbarmory`: USB Armory (ARMv7, hard float)
-- `-musl` is optional and indicates that the image uses the musl libc instead of glibc
-- `BUILD_DATE` is the date the image was built
-
-Connect to it in virtual terminal or via ssh and log in as `root`, password `voidlinux`.
-
-General instructions for these images are available [in the documentation](https://docs.voidlinux.org/installation/guides/arm-devices/index.html).
-
-## Download rootfs tarballs
-
-### Download rootfs tarballs for ARM
-
-There are rootfs tarballs available for all the **ARM** devices which have ready to boot images,
-as well as generic devices.
-
-For the devices which have ready to boot images, the tarballs are named
-`void-DEVICE[-musl]-PLATFORMFS-BUILD_DATE.tar.xz`, where all items mean the same as they do for ready to
-boot images, and `PLATFORMFS` marks it as a tarball.
-
-For generic devices, the tarballs are named `void-ARCH[-musl]-ROOTFS-BUILD_DATE.tar.xz`, where
-
-- `ARCH` is the architecture of the image, which can be:
-   - `armv6l`
-   - `armv7l`
-   - `aarch64`
-- `-musl` is optional and indicates that the image uses the musl libc instead of glibc
-- `BUILD_DATE` is the date the image was built
-
-General instructions for these images are available [in the documentation](https://docs.voidlinux.org/installation/guides/arm-devices/index.html).
-Specific instructions are available for the following platforms:
-
-- [Raspberry Pi, Raspberry Pi Zero, Raspberry Pi 2 and Raspberry Pi 3](https://docs.voidlinux.org/installation/guides/arm-devices/platforms.html#raspberry-pi)
-
-Deprecated instructions for the following platforms can be found in these wiki pages (you can help by porting them over to the [Void Handbook](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md)):
-
-- [BeagleBone/BeagleBone Black](https://wiki.voidlinux.org/Beaglebone)
-- [Cubieboard2](https://wiki.voidlinux.org/Cubieboard2_SD-Card)
-- [Odroid U2/U3](https://wiki.voidlinux.org/Odroid_U2)
-- [USB Armory](https://wiki.voidlinux.org/USB_Armory)
-
-### Download rootfs tarballs for x86
-
-There are also rootfs tarballs available for **x86** architectures. They are named
-`void-ARCH-ROOTFS-BUILD_DATE.tar.xz`, where all items mean the same as they do for the live images.


### PR DESCRIPTION
I have spent some time on  adding download links to the "Download" page and I'm curious what everyone think about this version:

| x86 | i686 | arm | nojs |
| ----- | ----- | --- | --- |
|  ![Screenshot_2020-10-06 Enter the void - Downloads](https://user-images.githubusercontent.com/673861/95148235-516afe80-07df-11eb-8c9f-fa8da1d4ca93.png)  |  ![Screenshot_2020-10-06 Enter the void - Downloads(1)](https://user-images.githubusercontent.com/673861/95148247-5b8cfd00-07df-11eb-8a25-0dc5aa396d60.png)  |  ![Screenshot_2020-10-06 Enter the void - Downloads(2)](https://user-images.githubusercontent.com/673861/95148256-621b7480-07df-11eb-9e45-05474789f2ba.png) | ![Screenshot_2020-10-06 Enter the void - Downloads(3)](https://user-images.githubusercontent.com/673861/95148270-68115580-07df-11eb-8a55-b3c30fa868bd.png) |

Notable changes:

- Pushed various archs to the tabs, I think users usually interested in the specific platform
- Added download links for all archs and flavors for live images and tarballs
- Tweaked details for each arch and pushed it to the side

The downside of these changes is that build date has to be updated in the config after each new build, I think it happens rarely so hopefully won't create too much load. If someone will notice that something is off, I'm happy to tweak it.