### PR TITLE
acknowledgements: Add pulux

### DIFF
--- a/acknowledgments/index.md
+++ b/acknowledgments/index.md
@@ -33,3 +33,8 @@ Leah Neukirchen sponsors the aarch64 build machine.
 ## [Tj Vanderpoel](#)
 
 Tj Vanderpoel sponsors the musl build machine.
+
+## [Pulux](#)
+
+Pulux sponsors b-lej-de, which hosts [Void's monitoring
+infrastructure](https://grafana.s.voidlinux.org/).


### PR DESCRIPTION
This adds acknowledgement for pulux hosting b-lej-de, but this host is down and I'd ideally like them to review this PR before I merge it to add their consulting company if they have one or otherwise make sure it looks right.