### PR TITLE
2020-05-01-new-contributors: point "Contribute Page" to docs.voidlinux.

### DIFF
--- a/_posts/2020-05-01-new-contributors.markdown
+++ b/_posts/2020-05-01-new-contributors.markdown
@@ -10,4 +10,5 @@ Joining us to work on packages is `@abenson`.
 Joining us to advance the docs site are `@flexibeast` and `@ericonr`.
 
 Interested in seeing your name in a future update here?  Read our
-[Contributing Page](/contribute/) and join us today!
+[Contributing Page](https://docs.voidlinux.org/contributing/index.html)
+and join us today!


### PR DESCRIPTION
https://voidlinux.org/contribute/ has been removed.

Fixes #121.