### PR TITLE
Use a non-generic name for the atom feed

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
 		<link rel="stylesheet" href="/assets/css/misc.css">
 		<link href='/assets/css/font-ubuntu.css' rel='stylesheet' type='text/css'>
 		{% if site.snow == 1 %}<link rel="stylesheet" type="text/css" href="/assets/css/snow.css" />{% endif %}
-		<link rel="alternate" type="application/atom+xml" title="Atom feed" href="/atom.xml" />
+		<link rel="alternate" type="application/atom+xml" title="Void Linux News feed" href="/atom.xml" />
 		<script src="/assets/js/jquery.min.js"></script>
 		<script src="/assets/js/bootstrap.min.js"></script>
 		<script src="/assets/js/tabbar.js"></script>


### PR DESCRIPTION
Applications with feed discovery use this name for the feed's title.
This change gives a better automatic name for the feed on feed readers.