### PR TITLE
add opengraph meta tags for rich url embeds on social sites

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,5 +17,12 @@ collections:
   platforms:
     output: true
 
+defaults:
+  - scope:
+      path: ""      # empty string for all files
+      type: posts   # limit to posts
+    values:
+      is_post: true # automatically set is_post=true for all posts
+
 download_mirror: https://alpha.de.repo.voidlinux.org/live/current
 download_build_date: 2021-02-18

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,24 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og: https://ogp.me/ns# article: http://ogp.me/ns/article#">
 	<head>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>{{ page.title }}</title>
+
+		<meta property="og:title" content="{{ page.title }}">
+		{% if page.is_post %}
+		<meta property="og:description" content="{{ page.excerpt | strip_html | normalize_whitespace }}">
+		<meta property="og:type" content="article">
+		<meta property="article:published_time" content="{{ page.date | date: "%Y-%m-%d" }}">
+		{% else %}
+		<meta property="og:description" content="{{ site.name }}">
+		{% endif %}
+		<meta property="og:site_name" content="Void Linux">
+		<meta property="og:image:url" content="/assets/img/voidlogo.png">
+		<meta property="og:image:alt" content="Void Linux Logo">
+		<meta name="theme-color" content="#478061">
+
 		<link rel="icon" type="image/png" href="/assets/img/favicon.png" />
 		<link rel="stylesheet" href="/assets/css/bootstrap.min.css">
 		<link rel="stylesheet" href="/assets/css/screen.css">


### PR DESCRIPTION
[opengraph](https://ogp.me/) is a standard for social websites (and other services) to display more info about a url's destination, based on a set of `<meta>` tags. In this PR, I implemented opengraph for voidlinux.org.

Here's how they currently render in discord:
![image](https://user-images.githubusercontent.com/5366828/135731075-9a8bf2f7-c85a-4995-ad17-0aa0a9b218cd.png)

I'm open to suggestions for the exact content of the embed; most of the pages are currently fairly simplistic, except for news posts, which have an excerpt of the post.