### PR TITLE
Adjust navbar to not hover page main content

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
 		<script src="/assets/js/tabbar.js"></script>
 	</head>
 	<body role="document">
-		<nav class="navbar navbar-default navbar-inverse navbar-fixed-top" role="navigation">
+		<nav class="navbar navbar-default navbar-inverse navbar-sticky" role="navigation">
 			<div class="container">
 				<div class="navbar-header">
 					<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#void-collapsed-navbar">

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1,6 +1,6 @@
 body {
 	font-family: 'Ubuntu', sans-serif;
-	padding-top: 70px; /* For bootstrap fixed navbar
+	/*
 	background-color: #111;
 	color: #ddd; */
 }
@@ -15,6 +15,13 @@ code {
 	font-size: 1.2em;
 	color: #fff;
 }
+
+.navbar-sticky {
+	position: sticky;
+	top: 0;
+	border-radius: 0;
+}
+
 
 .vcenter {
 	display: inline-block;


### PR DESCRIPTION
At about 900px width navbar breaks into two lines. It was hovering page
content on /download and /acknowledgments . Use dedicated css in place
of older technique of fixed margin. On older browsers navbar scrolls
together with page.

Demo at <https://chocimier.github.io/void-linux.github.io/download/>

Hovering titles on voidlinux.org is not a big deal, but it is at http://54.37.137.89/pkgs.void , searchbox is completely hidden.