### PR TITLE
Change navbar position (sticky to static)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
 		<script src="/assets/js/tabbar.js"></script>
 	</head>
 	<body role="document">
-		<nav class="navbar navbar-default navbar-inverse navbar-sticky" role="navigation">
+		<nav class="navbar navbar-default navbar-inverse navbar-static-top" role="navigation">
 			<div class="container">
 				<div class="navbar-header">
 					<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#void-collapsed-navbar">

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -16,12 +16,6 @@ code {
 	color: #fff;
 }
 
-.navbar-sticky {
-	position: sticky;
-	top: 0;
-	border-radius: 0;
-}
-
 
 .vcenter {
 	display: inline-block;


### PR DESCRIPTION
Fix: #168

Issue #168 cannot be resolved without adding the z-index.
However, pull request #169 has not been accepted.

So I thought of a non-hacky solution.
Unfortunately, Bootstrap3 doesn't support sticky navbar.
[Static top](https://getbootstrap.com/docs/3.4/components/#navbar-static-top) is the most appropriate.
Sticky position was cool, but it was also a disadvantage on narrow screens.
I think it's an acceptable change.