### PR TITLE
various: replace alpha.de links with repo-default

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,5 +24,5 @@ defaults:
     values:
       is_post: true # automatically set is_post=true for all posts
 
-download_mirror: https://alpha.de.repo.voidlinux.org/live/current
+download_mirror: https://repo-default.voidlinux.org/live/current
 download_build_date: 2021-09-30

--- a/_posts/2018-11-12-new-images.markdown
+++ b/_posts/2018-11-12-new-images.markdown
@@ -38,5 +38,5 @@ chroot and are available for all architectures we currently compile
 for.
 
 You can find all images and rootfs tarballs at
-[https://alpha.de.repo.voidlinux.org/live/current](https://alpha.de.repo.voidlinux.org/live/current),
+[https://repo-default.voidlinux.org/live/current](https://repo-default.voidlinux.org/live/current),
 or in the /live/current directory on any mirror near you.

--- a/_posts/2020-10-01-hacktoberfest.markdown
+++ b/_posts/2020-10-01-hacktoberfest.markdown
@@ -53,7 +53,7 @@ problems in the past with people adding packages and then abandoning
 them, so expect to meet significant resistance if you are a new
 contributor trying to add a package to the repo.  Updating packages is
 very easy.  You can select a package from the list of [out of date
-packages](http://alpha.de.repo.voidlinux.org/void-updates/void-updates.txt)
+packages](http://repo-default.voidlinux.org/void-updates/void-updates.txt)
 and update it using the tools in the [void-packages
 repo](https://github.com/void-linux/void-packages).  The
 [manual](https://github.com/void-linux/void-packages/blob/master/Manual.md)

--- a/_posts/2021-09-23-hacktoberfest.markdown
+++ b/_posts/2021-09-23-hacktoberfest.markdown
@@ -12,7 +12,7 @@ selection of packages and make sure your system remains up to date.
 
 Updating packages is very easy.  You can select a package from the
 list of [out of date
-packages](http://alpha.de.repo.voidlinux.org/void-updates/void-updates.txt)
+packages](http://repo-default.voidlinux.org/void-updates/void-updates.txt)
 and update it using the tools in the [void-packages
 repo](https://github.com/void-linux/void-packages).  The
 [manual](https://github.com/void-linux/void-packages/blob/master/Manual.md)


### PR DESCRIPTION
sets the downloads page to point to repo-default, and updates links in a few news posts to prevent link-rot

