### PR TITLE
add zindex to navbar

### DIFF
--- a/assets/css/misc.css
+++ b/assets/css/misc.css
@@ -165,6 +165,7 @@ img, .video {
 .navbar {
 	background-color:#478061;
 	border:0;
+	z-index: 9999;
 }
 .nav li:hover {
 	background-color: black;


### PR DESCRIPTION
Stops text overflowing with navbar when scrolling when the website so that nav links are readable.

Before:
![image](https://user-images.githubusercontent.com/69070214/184002108-edc414f2-98f5-4fe5-83e2-80ca9d9cac6c.png)

After:
![image](https://user-images.githubusercontent.com/69070214/184002153-6279c2d9-7ddd-496c-9431-b9139630bbb1.png)
