### PR TITLE
_includes/download_pc.html: simplify logic for live iso downloads

### DIFF
--- a/_includes/download_pc.html
+++ b/_includes/download_pc.html
@@ -8,45 +8,6 @@
     </div>
   </div>
   <div>
-    <div class="download-device-title">
-      <h4>base</h4>
-      <small>{{ site.download_build_date }}</small>
-    </div>
-    <ul class="inline-download-links">
-      <li>
-        <a
-          href="{{ site.download_mirror }}/void-live-{{ page.name }}-{{ site.download_build_date | date: '%Y%m%d' }}.iso"
-          >Live image</a
-        >
-        <span class="label label-default">glibc</span>
-      </li>
-      {% if page.supports_musl %}
-      <li>
-        <a
-          href="{{ site.download_mirror }}/void-live-{{ page.name }}-musl-{{ site.download_build_date | date: '%Y%m%d' }}.iso"
-          >Live image</a
-        >
-        <span class="label label-warning">musl</span>
-      </li>
-      {% endif %}
-      <li>
-        <a
-          href="{{ site.download_mirror }}/void-{{ page.name }}-ROOTFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
-          >rootfs tarball</a
-        >
-        <span class="label label-default">glibc</span>
-      </li>
-      {% if page.supports_musl %}
-      <li>
-        <a
-          href="{{ site.download_mirror }}/void-{{ page.name }}-musl-ROOTFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
-          >rootfs tarball</a
-        >
-        <span class="label label-warning">musl</span>
-      </li>
-      {% endif %}
-    </ul>
-
     {% for flavor in page.flavors %}
     <div class="download-device-title">
       <h4>{{ flavor | downcase }}</h4>
@@ -68,6 +29,24 @@
         >
         <span class="label label-warning">musl</span>
       </li>
+      {% endif %}
+      {% if flavor == "base" %}
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ page.name }}-ROOTFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
+          >rootfs tarball</a
+        >
+        <span class="label label-default">glibc</span>
+      </li>
+      {% if page.supports_musl %}
+      <li>
+        <a
+          href="{{ site.download_mirror }}/void-{{ page.name }}-musl-ROOTFS-{{ site.download_build_date | date: '%Y%m%d' }}.tar.xz"
+          >rootfs tarball</a
+        >
+        <span class="label label-warning">musl</span>
+      </li>
+      {% endif %}
       {% endif %}
     </ul>
     {% endfor %}

--- a/_platforms/i686.md
+++ b/_platforms/i686.md
@@ -1,7 +1,7 @@
 ---
 name: i686
 date: 1970-01-01 03:00:00
-flavors: [xfce]
+flavors: [base, xfce]
 supports_musl: false
 ---
 

--- a/_platforms/x86_64.md
+++ b/_platforms/x86_64.md
@@ -1,7 +1,7 @@
 ---
 name: x86_64
 date: 1970-01-01 01:00:00
-flavors: [xfce]
+flavors: [base, xfce]
 supports_musl: true
 ---
 


### PR DESCRIPTION
due to void-linux/void-mklive#275, the base image now has a consistent suffix, allowing for simplified logic in the downloads page.

Don't merge this until new images are released.

![image](https://user-images.githubusercontent.com/5366828/188252875-eaa479ad-2d79-4034-add5-aba1a70cae3e.png)
