### PR TITLE
assets/css/misc.css: add z-index to .navbar

### DIFF
--- a/assets/css/misc.css
+++ b/assets/css/misc.css
@@ -165,6 +165,7 @@ img, .video {
 .navbar {
 	background-color:#478061;
 	border:0;
+	z-index: 1;
 }
 .nav li:hover {
 	background-color: black;


### PR DESCRIPTION
This fixes the page contents going over the navbar while scrolling.

Z-index is used since that's the only solution that functions and gained consensus in #169.

Fixes #168
Closes #169 (same solution but with an absurd z-index value, and has been completely stalled)
Closes #172 (makes the navbar stick to the top of the document, not the top of the viewport)