### PR TITLE
Disable christmas mode

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ highlighter: rouge
 permalink:   /news/:year/:month/:title.html
 
 snow:        0
-christmas:   1
+christmas:   0
 
 plugins:
   - jekyll-redirect-from


### PR DESCRIPTION
_„Don't cry because it's over. Smile because it happened.“_ 
- Dr. Seuss

Sure, it's hard to let something as precious as Void Linux website christmas mode go, but sadly both Catholic and Orthodox christmases already happened and it's time to disable it again. Next year we will glimpse the beauty of it again, so don't be upset.