### PR TITLE
assets/css/misc.css: slightly redesigned navigation bar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
 		<script src="/assets/js/tabbar.js"></script>
 	</head>
 	<body role="document">
-		<nav class="navbar navbar-default navbar-inverse navbar-sticky" role="navigation">
+		<nav class="navbar navbar-sticky" role="navigation">
 			<div class="container">
 				<div class="navbar-header">
 					<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#void-collapsed-navbar">
@@ -41,7 +41,7 @@
 						<span class="icon-bar"></span>
 					</button>
 				</div>
-				<div class="collapse navbar-right navbar-collapse" id="void-collapsed-navbar">
+				<div class="collapse navbar-collapse" id="void-collapsed-navbar">
 					<ul class="nav navbar-nav">
 						<li><a href="/">Home</a></li>
 						<li><a href="/news/">News</a></li>

--- a/assets/css/misc.css
+++ b/assets/css/misc.css
@@ -163,12 +163,25 @@ img, .video {
 	padding-right: 8em;
 }
 .navbar {
-	background-color:#478061;
-	border:0;
-	z-index: 1;
+  border: 0;
+  border-bottom: 1px grey dotted;
+  z-index: 1;
+  background-color: inherit;
 }
-.nav li:hover {
-	background-color: black;
+#void-collapsed-navbar {
+  display: flex !important;
+  justify-content: center;
+}
+.nav li a {
+  color: inherit;
+}
+.nav li a:hover {
+  box-shadow: inset 0 -2px 0 0 #295340;
+  background-color: transparent;
+}
+.nav li a:focus {
+  background-color: transparent;
+  color: inherit;
 }
 h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
 	padding-top:50px;
@@ -324,9 +337,6 @@ h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
   select::-ms-expand {
     display:none;
   }
-  .nav li:hover {
-    background-color: #222;
-  }
   .inline-download-links .label-default, .inline-download-links .label-warning {
     background-color: inherit;
   }
@@ -337,9 +347,6 @@ h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
   .inline-download-links .label-warning {
     border: 1px solid;
     color: #ffd804;
-  }
-  .navbar {
-    background-color: #295340;
   }
   #davoid .fg.standard-mode {
     content: url(/assets/img/void_fg_dark.png);


### PR DESCRIPTION
This PR redesigns the navbar header, in order to fit the rest of the website better (in my opinion) and look a bit more modern.
When hovering a navbar item, it is getting underlined.

Screenshots below:

![dark](https://github.com/void-linux/void-linux.github.io/assets/82752168/1854ec17-49aa-4c37-ad25-c7f36f051d80)
![light](https://github.com/void-linux/void-linux.github.io/assets/82752168/a7c82f71-0665-419f-9a29-8ad0f693d87c)

In case this would be accepted, I'd open a PR for the same at the docs repo.