### PR TITLE
fix: content overflow on download page

### DIFF
--- a/assets/css/misc.css
+++ b/assets/css/misc.css
@@ -191,6 +191,7 @@ h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
   padding: 0;
   margin: 0;
   border-bottom: 1px solid #ddd;
+  overflow: auto;
 }
 .tab-bar li {
   padding: 1em 2em;


### PR DESCRIPTION
## fixes #219 

## What it does:
This PR adds an `overflow` property with `auto` value to the `.tab-bar` class, which makes the element scroll-able on overflowing scenarios.