### PR TITLE
index: link to mastodon, not twitter

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ title: Enter the void
 		</p>
 		<p>It is available for a variety of platforms. Software packages can be built natively or cross compiled through the <a href="https://github.com/void-linux/void-packages">XBPS source packages collection</a>.
 		</p>
-		<p>Follow us on <a href="https://twitter.com/voidlinux" title="Void on Twitter">Twitter</a>, visit the <a href="ircs://irc.libera.chat/#voidlinux">#voidlinux</a> IRC channel on <a href="https://libera.chat">libera.chat</a>, and join the <a href="https://www.reddit.com/r/voidlinux/">Void Linux subreddit</a>.
+		<p>Follow us on <a rel="me" href="https://chaos.social/@voidlinux" title="Void on Mastodon">Mastodon</a>, visit the <a href="ircs://irc.libera.chat/#voidlinux">#voidlinux</a> IRC channel on <a href="https://libera.chat">libera.chat</a>, and join the <a href="https://www.reddit.com/r/voidlinux/">Void Linux subreddit</a>.
 		</p>
 		<p>Visit the <a href="https://build.voidlinux.org" title="Void builder">Void build server console</a> for package build status updates.
 		</p>


### PR DESCRIPTION
`rel="me"` allows mastodon to put a "verified" mark next to the link on the profile.

see also: 3df770f14646ac39d3ddc165a6cdc3fdb1f0b6f6
