### PR TITLE
_layouts/default: sync navbar with void-infrastructure

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,15 +41,18 @@
 						<span class="icon-bar"></span>
 					</button>
 				</div>
-				<div class="collapse navbar-right navbar-collapse" id="void-collapsed-navbar">
-					<ul class="nav navbar-nav">
+				<div class="collapse navbar-collapse" id="void-collapsed-navbar">
+					<ul class="nav navbar-left navbar-nav">
 						<li><a href="/">Home</a></li>
 						<li><a href="/news/">News</a></li>
 						<li><a href="/download/">Download</a></li>
 						<li><a href="/packages/">Packages</a></li>
 						<li><a href="/acknowledgments/">Acknowledgments</a></li>
+					</ul>
+					<ul class="nav navbar-right navbar-nav">
 						<li><a href="https://docs.voidlinux.org">Documentation</a></li>
 						<li><a href="https://man.voidlinux.org/">Manual Pages</a></li>
+						<li><a href="https://xmirror.voidlinux.org/">Mirrors</a></li>
 						<li><a href="https://github.com/void-linux">GitHub</a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
The navbar is out of sync between void-linux.github.io, [void-infrastructure](https://github.com/void-linux/void-infrastructure/blob/4944ca70976c75e01d1d460bfb979cf8e72f5a4c/services/pkg/man-cgi/header.html), and [void-docs](https://github.com/void-linux/void-docs/blob/master/src/theme/index.hbs).

Most notably, the link to xmirror.voidlinux.org is missing from here and void-docs.

I also changed the layout to follow navbar-right/navbar-left used by the void-infrastructure navbar, if you want me to revert that, let me know.

Ofc feedback/criticism is welcome.

before:
![Screenshot 2025-03-23 at 23-33-51 Enter the void](https://github.com/user-attachments/assets/27994126-c6c6-4648-af7f-ad13a5ad4cc2)
man-cgi:
![Screenshot 2025-03-23 at 23-34-04 Void Linux manpages](https://github.com/user-attachments/assets/0e0651dc-db8e-431a-9ef9-c632db4fc9b3)
this pr:
![Screenshot 2025-03-23 at 23-40-48 Enter the void](https://github.com/user-attachments/assets/d3719d2e-34d7-42bf-83f2-f5955c749ba1)


