### PR TITLE
add: package name input autofocus and focus on '/' key press

### DIFF
--- a/assets/js/voidsearch.js
+++ b/assets/js/voidsearch.js
@@ -55,6 +55,14 @@
                 setArchitectures(data.data.sort());
                 initPackageQuery();
             });
+
+        // focus #voidSearch_query input on '/' keypress
+        $(d).on("keydown", (e) => {
+            if (e.key === "/" && !$("input:focus").length) {
+                e.preventDefault();
+                query.focus();
+            }
+        });
     }
 
     function initPackageQuery() {

--- a/packages/index.markdown
+++ b/packages/index.markdown
@@ -13,7 +13,7 @@ title: Enter the void - Packages
   </select>
  </div>
  <div class="form-group">
-  <input type="text" name="q" placeholder="Package or description" class="form-control" id="voidSearch_query"/>
+  <input type="text" name="q" placeholder="Package or description" class="form-control" id="voidSearch_query" autofocus/>
  </div>
  <button type="submit" class="btn btn-green" id="voidSearch_submit">Search</button>
 </form>


### PR DESCRIPTION
I added an autofocus attribute to the `#voidSearch_query` field on the /packages page and some JQuery to focus that text field when '/' is pressed. 

Maybe the autofocus thing is a bit too intrusive so we could just keep the JQuery but the idea behind it was that I don't like to have to reach for my mouse and click on the text field and then type in my query when I'm browsing packages.